### PR TITLE
Reduce the number of code to read /proc/net/tcp

### DIFF
--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -8,7 +8,7 @@ import (
 	gnet "github.com/shirou/gopsutil/net"
 )
 
-// LocalListeningPorts returns the local listening ports.
+// FilterByLocalListeningPorts filters ConnectionStat slice by the local listening ports.
 // eg. [199, 111, 46131, 53, 8953, 25, 2812, 80, 8081, 22]
 // -----------------------------------------------------------------------------------
 // [y_uuki@host ~]$ netstat -tln
@@ -24,11 +24,7 @@ import (
 // tcp        0      0 :::80                       :::*                        LISTEN
 // tcp        0      0 :::8081                     :::*                        LISTEN
 // tcp        0      0 :::22                       :::*                        LISTEN
-func LocalListeningPorts() ([]string, error) {
-	conns, err := gnet.Connections("tcp")
-	if err != nil {
-		return nil, err
-	}
+func FilterByLocalListeningPorts(conns []gnet.ConnectionStat) ([]string, error) {
 	ports := []string{}
 	for _, conn := range conns {
 		if conn.Status != "LISTEN" {
@@ -39,6 +35,15 @@ func LocalListeningPorts() ([]string, error) {
 		}
 	}
 	return ports, nil
+}
+
+// LocalListeningPorts returns the local listening ports.
+func LocalListeningPorts() ([]string, error) {
+	conns, err := gnet.Connections("tcp")
+	if err != nil {
+		return nil, err
+	}
+	return FilterByLocalListeningPorts(conns)
 }
 
 // ResolveAddr lookup first hostname from IP Address.

--- a/netutil/netutil_test.go
+++ b/netutil/netutil_test.go
@@ -1,6 +1,8 @@
 package netutil
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestLocalIPAddrss(t *testing.T) {
 	addrs, err := LocalIPAddrs()
@@ -8,6 +10,16 @@ func TestLocalIPAddrss(t *testing.T) {
 		t.Fatalf("should not raise error: %v", err)
 	}
 	if len(addrs) == 0 {
+		t.Error("localIPAddrs() should not be len == 0")
+	}
+}
+
+func TestLocalListeningPorts(t *testing.T) {
+	ports, err := LocalListeningPorts()
+	if err != nil {
+		t.Fatalf("should not raise error: %v", err)
+	}
+	if len(ports) == 0 {
 		t.Error("localIPAddrs() should not be len == 0")
 	}
 }

--- a/tcpflow/tcpflow.go
+++ b/tcpflow/tcpflow.go
@@ -112,11 +112,11 @@ func (hf HostFlows) insert(flow *HostFlow) {
 
 // GetHostFlows reads /proc/net/tcp and wraps it as HostFlows.
 func GetHostFlows() (HostFlows, error) {
-	ports, err := netutil.LocalListeningPorts()
+	conns, err := gnet.Connections("tcp")
 	if err != nil {
 		return nil, err
 	}
-	conns, err := gnet.Connections("tcp")
+	ports, err := netutil.FilterByLocalListeningPorts(conns)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
[y_uuki@hoge ~]$ time bash -c 'ss -tan | wc -l'
30370

real	0m0.057s
user	0m0.044s
sys	0m0.016s
```

# Before

```
[y_uuki@hoge ~]$ time lstf -n
...
real	0m0.801s
user	0m0.404s
sys	0m0.360s
```

# After

```
[y_uuki@hoge ~]$ time lstf -n
...
real	0m0.478s
user	0m0.228s
sys	0m0.212s
```