### PR TITLE
Fix an error of parsing spesific comm pattern

### DIFF
--- a/netutil/netutil_linux.go
+++ b/netutil/netutil_linux.go
@@ -204,18 +204,13 @@ func parseProcStat(root string, pid int) (*procStat, error) {
 		ppid  int
 		pgrp  int
 	)
-	if _, err := fmt.Fscan(f, &pid2, &comm, &state, &ppid, &pgrp); err != nil {
+	if _, err := fmt.Fscanf(f, "%d %s %s %d %d",
+		&pid2, &comm, &state, &ppid, &pgrp); err != nil {
 		return nil, xerrors.Errorf("could not scan '%s': %w", stat, err)
 	}
 
-	var pname string
-	// workaround: Sscanf return io.ErrUnexpectedEOF without knowing why.
-	if _, err := fmt.Sscanf(comm, "(%s)", &pname); err != nil && err != io.ErrUnexpectedEOF {
-		return nil, xerrors.Errorf("could not scan '%s': %w", comm, err)
-	}
-
 	return &procStat{
-		Pname: strings.TrimRight(pname, ")"),
+		Pname: comm[1 : len(comm)-1], // remove '(' and ')'
 		Ppid:  ppid,
 		Pgrp:  pgrp,
 	}, nil


### PR DESCRIPTION
lstf could nor parse /proc/<pid>/stat when 'comm' includes white spaces. 
An example of the error is given below.

```shell
ubuntu@shawk-client-01:~$ sudo ./lstf -p
failed to get host flows: could not scan '/proc/29012/stat': expected integer

ubuntu@shawk-client-01:~$ cat /proc/29012/stat
29012 (tmux: server) S 1 29012 29012 0 -1 4194368 2361 2615 23 0 2895 3439 5 2 20 0 1 0 119870728 15785984 2055 18446744073709551615 94871655624704 94871656090997 140723248783936 0 0 0 0 528386 134433281 1 0 0 17 1 0 0 1 0 0 94871656250096 94871656298312 94871687729152 140723248785484 140723248785489 140723248785489 140723248787434 0
```